### PR TITLE
fix: Update title and description for NVIDIA Blackwell GPUs page

### DIFF
--- a/src/pages/nvidia-blackwell-gpus.astro
+++ b/src/pages/nvidia-blackwell-gpus.astro
@@ -23,7 +23,10 @@ const products = [
 ];
 ---
 
-<Layout title="NVIDIA Blackwell GPUs - Coming Soon">
+<Layout
+  title="NVIDIA Blackwell GPUs"
+  description="The NVIDIA GB200 Grace Blackwell Superchip, along with NVIDIA Blackwell GPUs, will be available soon on Akash."
+>
   <TopMargin className="container-small" isNotContainer>
     <section
       class="flex min-h-screen flex-col gap-12 lg:grid lg:grid-cols-2 lg:gap-20"
@@ -38,7 +41,7 @@ const products = [
           </p>
           <p class="text-para md:text-lg">
             The NVIDIA GB200 Grace Blackwell Superchip, along with NVIDIA
-            Blackwell GPUs, will soon be available on Akash.
+            Blackwell GPUs, will be available soon on Akash.
           </p>
         </div>
 


### PR DESCRIPTION
- Changed the page title to "NVIDIA Blackwell GPUs" for clarity.
- Added a description to the layout, highlighting the upcoming availability of the NVIDIA GB200 Grace Blackwell Superchip and Blackwell GPUs on Akash.
- Minor text adjustment in the product availability statement for improved readability.