### PR TITLE
Refactor GPU sorting logic in pricing page

### DIFF
--- a/src/components/pricing-page/gpus/sort.tsx
+++ b/src/components/pricing-page/gpus/sort.tsx
@@ -11,7 +11,7 @@ const publishingOptions = [
 ];
 
 export const onTop = (res?: Gpus) => {
-  const onTop = ["h100", "h200", "a100"];
+  const onTop = ["h200", "h100", "a100"];
   const filtered = res?.models
     ?.filter((model) => onTop?.includes(model?.model))
     .sort((a, b) => onTop.indexOf(a?.model) - onTop.indexOf(b?.model));


### PR DESCRIPTION
- Updated the order of models in the `onTop` array within the `sort.tsx` file to prioritize "h200" over "h100". This change improves the sorting mechanism for GPU models displayed on the pricing page, ensuring that the preferred model appears first in the filtered results.

These changes aim to enhance the user experience by providing a more relevant display of GPU options.