### PR TITLE
Menu buttons clickable

### DIFF
--- a/src/components/header/popovers/popover-nav-community.tsx
+++ b/src/components/header/popovers/popover-nav-community.tsx
@@ -30,20 +30,23 @@ const PopOverSmall = ({
       className="relative inline-block text-left"
       onMouseLeave={() => setOpen(false)}
     >
-      <div>
-        <Menu.Button
-          onMouseEnter={() => {
-            setOpen(true);
-          }}
-          className="inline-flex cursor-pointer items-center justify-center text-sm font-medium capitalize leading-normal hover:text-primary xl:text-sm "
-        >
-          {type}
-          <ChevronDownIcon
-            className="text-gra -mr-1 ml-1 h-4 w-4"
-            aria-hidden="true"
-          />
-        </Menu.Button>
-      </div>
+      <a
+        href={
+          type === "community"
+            ? communityItems[0].link
+            : developmentItems[0].link
+        }
+        onMouseEnter={() => {
+          setOpen(true);
+        }}
+        className="inline-flex cursor-pointer items-center justify-center text-sm font-medium capitalize leading-normal hover:text-primary xl:text-sm "
+      >
+        {type}
+        <ChevronDownIcon
+          className="text-gra -mr-1 ml-1 h-4 w-4"
+          aria-hidden="true"
+        />
+      </a>
 
       <Transition
         show={open2}

--- a/src/components/header/popovers/popover-nav-item-ecosystem.tsx
+++ b/src/components/header/popovers/popover-nav-item-ecosystem.tsx
@@ -19,18 +19,19 @@ const PopOverNavItemEcosystem = ({
       className="relative inline-block text-left"
     >
       <div>
-        <Menu.Button
+        <a
+          href={ecosystemNavItems[0].link}
+          className="inline-flex cursor-pointer items-center justify-center text-sm font-medium leading-normal hover:text-primary xl:text-sm "
           onMouseEnter={() => {
             setOpen(true);
           }}
-          className="inline-flex cursor-pointer items-center justify-center text-sm font-medium leading-normal hover:text-primary xl:text-sm "
         >
           Ecosystem
           <ChevronDownIcon
             className="text-gra -mr-1 ml-1 h-4 w-4"
             aria-hidden="true"
           />
-        </Menu.Button>
+        </a>
       </div>
 
       <Transition

--- a/src/components/header/popovers/popover-nav-item.tsx
+++ b/src/components/header/popovers/popover-nav-item.tsx
@@ -15,18 +15,19 @@ const PopOverNavItemNetwork = () => {
       className="relative inline-block text-left"
     >
       <div>
-        <Menu.Button
+        <a
+          href={networkItems[0].link}
+          className="inline-flex cursor-pointer items-center justify-center text-sm font-medium leading-normal hover:text-primary xl:text-sm "
           onMouseEnter={() => {
             setOpen(true);
           }}
-          className="inline-flex cursor-pointer items-center justify-center text-sm font-medium leading-normal hover:text-primary xl:text-sm "
         >
           Network
           <ChevronDownIcon
             className="text-gra -mr-1 ml-1 h-4 w-4"
             aria-hidden="true"
           />
-        </Menu.Button>
+        </a>
       </div>
 
       <Transition


### PR DESCRIPTION
…components

Updated PopOverSmall, PopOverNavItemEcosystem, and PopOverNavItemNetwork to use anchor tags instead of Menu.Button for better accessibility and direct linking to respective pages. This change enhances user interaction by allowing direct navigation on mouse enter.

[https://github.com/akash-network/website/issues/495](url)