### PR TITLE
feat: add noIndex prop to various components for SEO control

### DIFF
--- a/src/components/base-head.astro
+++ b/src/components/base-head.astro
@@ -3,11 +3,17 @@ interface Props {
   title: string;
   description?: string;
   image?: string;
+  noIndex?: boolean;
 }
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
-const { title, description, image = "/meta-images/home.png" } = Astro.props;
+const {
+  title,
+  description,
+  image = "/meta-images/home.png",
+  noIndex,
+} = Astro.props;
 ---
 
 <!-- Global Metadata -->
@@ -32,6 +38,8 @@ const { title, description, image = "/meta-images/home.png" } = Astro.props;
 />
 <!-- Canonical URL -->
 <link rel="canonical" href={canonicalURL} />
+
+{noIndex && <meta name="robots" content="noindex, nofollow" />}
 
 <link
   rel="alternate"

--- a/src/components/pricing-page/gpus/availability-bar.tsx
+++ b/src/components/pricing-page/gpus/availability-bar.tsx
@@ -6,20 +6,33 @@ interface AvailabilityBarProps {
   available: number;
   total: number;
   className?: string;
+  counts?: boolean;
 }
 
 const AvailabilityBar: React.FC<AvailabilityBarProps> = ({
   available,
   total,
   className,
+  counts,
 }) => {
   const percentageFilled = Math.round(((total - available) / total) * 100);
 
   return (
     <div className={clsx("my-5 flex flex-col gap-1.5", className)}>
-      <span className="text-lg font-semibold text-foreground md:text-sm lg:text-base">
-        {percentageFilled}% Utilized
-      </span>
+      {counts ? (
+        <div className="flex items-center justify-between">
+          <span className="text-lg font-semibold text-foreground md:text-sm lg:text-base">
+            {available} Available
+          </span>
+          <span className="rounded border px-1.5 py-[1px] text-xs font-medium text-para">
+            Total: {total}
+          </span>
+        </div>
+      ) : (
+        <span className="text-lg font-semibold text-foreground md:text-sm lg:text-base">
+          {percentageFilled}% Utilized
+        </span>
+      )}
       <div className="relative h-[3px] w-full rounded-full border border-[#8F8F8F] bg-[#A8A8A8] dark:border-zinc-700 dark:bg-zinc-500">
         <div
           className="absolute -top-[1px] bottom-[-1px] left-[-1px]  bg-background"

--- a/src/components/pricing-page/gpus/desktop-table-gpu.tsx
+++ b/src/components/pricing-page/gpus/desktop-table-gpu.tsx
@@ -16,10 +16,12 @@ const DesktopTableGpu = ({
   subCom,
   isLoading,
   filteredData,
+  counts,
 }: {
   subCom: boolean;
   isLoading: boolean;
   filteredData: Gpus["models"];
+  counts?: boolean;
 }) => {
   const [hoveredRowIndex, setHoveredRowIndex] = useState<number | null>(null);
 
@@ -152,6 +154,7 @@ const DesktopTableGpu = ({
                     <AvailabilityBar
                       available={model?.availability?.available}
                       total={model?.availability?.total}
+                      counts={counts}
                     />
                   </td>
                   <td className="border-y border-r p-0">

--- a/src/components/pricing-page/gpus/gpu-availability.tsx
+++ b/src/components/pricing-page/gpus/gpu-availability.tsx
@@ -4,10 +4,12 @@ const GpuAvailability = ({
   totalGpus,
   totalAvailableGpus,
   isLoading,
+  counts,
 }: {
   totalGpus: number;
   totalAvailableGpus: number;
   isLoading: boolean;
+  counts?: boolean;
 }) => {
   const usedGpus = totalGpus - totalAvailableGpus;
   const usedPercentage = (usedGpus / totalGpus) * 100;
@@ -24,19 +26,23 @@ const GpuAvailability = ({
       <div className="flex gap-1">
         {isLoading ? (
           <>
-            <Skeleton className="h-8 w-32 rounded-full dark:bg-darkGray" />
+            {counts && (
+              <Skeleton className="h-8 w-32 rounded-full dark:bg-darkGray" />
+            )}
             <Skeleton className="h-8 w-64 rounded-full dark:bg-darkGray" />
           </>
         ) : (
           <>
-            <div className="flex items-center gap-1.5 rounded-full  border border-darkGrayBorder bg-lightGray px-4 py-1 dark:border-defaultBorder dark:bg-background2 ">
-              <p className="text-xs font-medium text-darkGrayText dark:text-para">
-                Total GPUs:
-              </p>
-              <p className="text-sm font-semibold text-foreground">
-                {totalGpus}
-              </p>
-            </div>
+            {counts && (
+              <div className="flex items-center gap-1.5 rounded-full  border border-darkGrayBorder bg-lightGray px-4 py-1 dark:border-defaultBorder dark:bg-background2 ">
+                <p className="text-xs font-medium text-darkGrayText dark:text-para">
+                  Total GPUs:
+                </p>
+                <p className="text-sm font-semibold text-foreground">
+                  {totalGpus}
+                </p>
+              </div>
+            )}
             <div className="flex items-center  gap-1.5 rounded-full border border-darkGrayBorder bg-lightGray px-4 py-1 dark:border-defaultBorder dark:bg-background2 ">
               <div className="flex items-center gap-1.5">
                 <p className="text-xs  font-medium text-darkGrayText dark:text-para">

--- a/src/components/pricing-page/gpus/gpu-table.tsx
+++ b/src/components/pricing-page/gpus/gpu-table.tsx
@@ -45,9 +45,11 @@ export interface Gpus {
 const GpuTable = ({
   initialData,
   subCom,
+  counts,
 }: {
   initialData?: any;
   subCom?: boolean;
+  counts?: boolean;
 }) => {
   const queryClient = new QueryClient();
 
@@ -58,6 +60,7 @@ const GpuTable = ({
           data: initialData,
         }}
         subCom={subCom}
+        counts={counts}
       />
     </QueryClientProvider>
   );
@@ -68,11 +71,13 @@ export default GpuTable;
 const Table = ({
   initialData,
   subCom,
+  counts,
 }: {
   initialData?: {
     data: any;
   };
   subCom?: boolean;
+  counts?: boolean;
 }) => {
   const fetchInterval = 1000 * 60;
 
@@ -100,6 +105,7 @@ const Table = ({
       data={data}
       subCom={subCom}
       isLoading={isLoading || isInitialLoading}
+      counts={counts}
     />
   );
 };
@@ -133,11 +139,13 @@ export const Tables = ({
   pathName,
   subCom,
   isLoading,
+  counts,
 }: {
   data?: Gpus;
   pathName?: any;
   subCom?: boolean;
   isLoading?: boolean;
+  counts?: boolean;
 }) => {
   const [filteredData, setFilteredData] = React.useState<Gpus["models"]>([]);
   const [filters, setFilters] = React.useState<Filters>(defaultFilters);
@@ -169,6 +177,7 @@ export const Tables = ({
           totalGpus={totalGpus}
           totalAvailableGpus={totalAvailableGpus}
           isLoading={isLoading || false}
+          counts={counts}
         />
 
         <Filter
@@ -179,18 +188,22 @@ export const Tables = ({
         />
       </div>
       <div className="flex flex-col gap-1 xl:hidden">
-        <p className="text-sm text-[#7E868C] md:text-base">
-          Total Available GPUs
-        </p>
+        {counts && (
+          <p className="text-sm text-[#7E868C] md:text-base">
+            Total Available GPUs
+          </p>
+        )}
         <div className="my-2 flex justify-between">
-          <Card className="px-2 py-1">
-            <span className="font-bold text-[#09090B] dark:text-[#EDEDED]">
-              {totalAvailableGpus || 0}{" "}
-            </span>
-            <span className="text-sm text-[#71717A]">
-              (of {totalGpus || 0})
-            </span>
-          </Card>
+          {counts && (
+            <Card className="px-2 py-1">
+              <span className="font-bold text-[#09090B] dark:text-[#EDEDED]">
+                {totalAvailableGpus || 0}{" "}
+              </span>
+              <span className="text-sm text-[#71717A]">
+                (of {totalGpus || 0})
+              </span>
+            </Card>
+          )}
           <div className="flex gap-1">
             <OFilter
               filters={filters}
@@ -274,6 +287,7 @@ export const Tables = ({
                   available={model?.availability?.available}
                   total={model?.availability?.total}
                   className="my-0 border-y py-5"
+                  counts={counts}
                 />
 
                 <div className="flex flex-col  justify-center gap-1 border-b pb-6 pt-2">
@@ -360,6 +374,7 @@ export const Tables = ({
         subCom={subCom || false}
         isLoading={isLoading || false}
         filteredData={filteredData}
+        counts={counts}
       />
     </section>
   );

--- a/src/components/pricing-page/pricing-header.astro
+++ b/src/components/pricing-page/pricing-header.astro
@@ -5,15 +5,17 @@ type Props = {
   title: string;
   description: string;
   image?: string;
+  noIndex?: boolean;
 };
 
-const { title, description, image } = Astro.props;
+const { title, description, image, noIndex } = Astro.props;
 ---
 
 <Layout
   title={`${title} | Explore Pricing and Earnings on Akash`}
   description={description}
   image={image || "/meta-images/gpus.png"}
+  noIndex={noIndex}
 >
   <section
     class="container mx-auto flex max-w-[1380px] flex-col gap-12 pt-12 md:gap-[4.5rem] md:pt-[100px]"

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -14,9 +14,10 @@ interface Props {
   description?: string;
   image?: string;
   classname?: string;
+  noIndex?: boolean;
 }
 
-const { title, description, image, classname } = Astro.props;
+const { title, description, image, classname, noIndex } = Astro.props;
 
 const isProd = import.meta.env.PROD;
 ---
@@ -55,7 +56,12 @@ const isProd = import.meta.env.PROD;
       })(window, document, "script", "dataLayer", "GTM-573RDG5H");
     </script>
 
-    <BaseHead title={title} description={description} image={image} />
+    <BaseHead
+      title={title}
+      description={description}
+      image={image}
+      noIndex={noIndex}
+    />
     <ViewTransitions />
   </head>
   <body class="bg-background" class:list={classname}>

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -13,17 +13,23 @@ interface Props {
   title: string;
   description?: string;
   image?: string;
+  noIndex?: boolean;
 }
 
 const homepage = await getEntry("Homepage", "index");
 
 const { advert } = homepage.data;
 
-const { title, description, image } = Astro.props;
+const { title, description, image, noIndex } = Astro.props;
 const pathname = Astro.url.pathname;
 ---
 
-<BaseLayout title={title} description={description} image={image}>
+<BaseLayout
+  title={title}
+  description={description}
+  image={image}
+  noIndex={noIndex}
+>
   {
     advert && !pathname.includes("neurips") && (
       <div class="flex items-center justify-center bg-primary px-3 py-2">

--- a/src/pages/current-groups/[...slug].astro
+++ b/src/pages/current-groups/[...slug].astro
@@ -220,7 +220,7 @@ const pathname = new URL(Astro.request.url).pathname;
           />
         </div>
 
-        <div class="space-y-10">
+        <div class="mt-6 space-y-10 md:mt-0">
           <div class="flex flex-col gap-6 lg:flex-row lg:items-center">
             <ButtonLink
               link={page.data.discordLink}

--- a/src/pages/internalgpucounts.astro
+++ b/src/pages/internalgpucounts.astro
@@ -1,0 +1,13 @@
+---
+import GpuTable from "@/components/pricing-page/gpus/gpu-table";
+import PricingHeader from "@/components/pricing-page/pricing-header.astro";
+---
+
+<PricingHeader
+  title="GPU Pricing and Availability"
+  description=" Browse the list of available GPUs along with their hourly rates."
+  image="/meta-images/pricing/gpu.jpg"
+  noIndex
+>
+  <GpuTable initialData={null} client:load counts />
+</PricingHeader>


### PR DESCRIPTION
- Introduced a noIndex prop in BaseHead, BaseLayout, and PricingHeader components to manage indexing behavior.
- Updated GPU availability components to conditionally display counts based on the new prop.
- Enhanced the GPU table and related components to support the counts feature for better availability insights.
- Created a new internal GPU counts page utilizing the updated components.