### PR TITLE
refactor: hide top banner

### DIFF
--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -45,26 +45,26 @@ const pathname = Astro.url.pathname;
   noIndex={noIndex}
   classname={classname}
 >
-  {
-    advert && !pathname.includes("neurips") && (
-      <div class="flex items-center justify-center bg-primary px-3 py-2">
-        <a
-          id="advert-to-gpus"
-          href={advert?.link}
-          target={
-            advert?.link.startsWith("/") || advert?.link.startsWith("#")
-              ? "_self"
-              : "_blank"
-          }
-        >
-          <p
-            class="text-center text-sm font-semibold text-white underline"
-            set:html={advert?.title}
-          />
-        </a>
-      </div>
-    )
-  }
+  <!-- { -->
+  <!--   advert && !pathname.includes("neurips") && ( -->
+  <!--     <div class="flex items-center justify-center bg-primary px-3 py-2"> -->
+  <!--       <a -->
+  <!--         id="advert-to-gpus" -->
+  <!--         href={advert?.link} -->
+  <!--         target={ -->
+  <!--           advert?.link.startsWith("/") || advert?.link.startsWith("#") -->
+  <!--             ? "_self" -->
+  <!--             : "_blank" -->
+  <!--         } -->
+  <!--       > -->
+  <!--         <p -->
+  <!--           class="text-center text-sm font-semibold text-white underline" -->
+  <!--           set:html={advert?.title} -->
+  <!--         /> -->
+  <!--       </a> -->
+  <!--     </div> -->
+  <!--   ) -->
+  <!-- } -->
 
   <Header overrideClassName={headerClassName} hideDarkToggle={hideDarkToggle} />
 
@@ -77,7 +77,7 @@ const pathname = Astro.url.pathname;
       pathname.includes("akash-accelerate-2024") ||
         pathname.includes("akash-accelerate-2025")
         ? "hidden"
-        : "block"
+        : "block",
     )}
   >
     <CTA />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change that removes a conditional marketing banner from the global layout; no data handling or security-sensitive logic is affected.
> 
> **Overview**
> Disables the conditional top-of-page advert banner in `src/layouts/layout.astro` by commenting out its render block, so it no longer appears on any pages.
> 
> Makes a small formatting-only tweak to the `clsx` call (adds a trailing comma) with no behavioral impact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d92538687b60541ac5d7b9f467fc74c360796d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->