### PR TITLE
fix: move contentsquare script into head tag for homepage

### DIFF
--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -134,6 +134,7 @@ const htmlDataTheme = onlyDark ? "dark-plus" : undefined;
       id="mathjax"
       src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
     <ViewTransitions />
+    <slot name="head" />
   </head>
   <body class="bg-background" class:list={classname}>
     <!-- Google Tag Manager (noscript) -->

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -45,6 +45,7 @@ const pathname = Astro.url.pathname;
   noIndex={noIndex}
   classname={classname}
 >
+  <slot name="head" slot="head" />
   {
     advert && !pathname.includes("neurips") && (
       <div class="flex items-center justify-center bg-primary px-3 py-2">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,10 +35,6 @@ const {
 } = homepage?.data;
 ---
 
-<head>
-  <script src="https://t.contentsquare.net/uxa/f3d653170e755.js"></script>
-</head>
-
 <Layout
   classname=" bg-[#FCFCFC] dark:bg-[#030303] "
   headerClassName="bg-[#F5F5F5] dark:bg-[#0a0a0a] top-0 sticky z-[30] border-b border-[#dddddd] dark:border-[#282828]"
@@ -46,6 +42,7 @@ const {
   footerClassName="dark:bg-[#000000] container-nav-3 border-t dark:border-[#282828]"
   description="Akash is an open network that lets users buy and sell computing resources securely and efficiently. Purpose-built for public utility."
 >
+  <script is:inline slot="head" src="https://t.contentsquare.net/uxa/f3d653170e755.js"></script>
   <div>
     <Hero heroSection={heroSection} />
     <div class="bg-[#F1F1F1] dark:bg-[#101010] w-full h-fit"><TrustedBy /></div>


### PR DESCRIPTION
## Summary
- Moved the ContentSquare script from an orphaned `<head>` tag into the actual document `<head>` via a named slot
- Script loads only on the homepage
- Added a `head` named slot through the layout chain (`base-layout.astro` → `layout.astro`) so pages can optionally inject scripts into `<head>`

## Test plan
- [ ] View page source on homepage — script should appear inside `<head>`
- [ ] View page source on other pages — script should NOT be present
- [ ] Verify ContentSquare is loading correctly in browser DevTools Network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)