### PR TITLE
fix: improve pagespeed score

### DIFF
--- a/src/components/base-head.astro
+++ b/src/components/base-head.astro
@@ -25,20 +25,39 @@ const {
 <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
 <meta name="generator" content={Astro.generator} />
 
-<!-- HubSpot Form Script -->
-<script src="https://js.hsforms.net/forms/embed/47519938.js" defer></script>
+<!-- DNS prefetch for third-party domains -->
+<link rel="dns-prefetch" href="https://js.hsforms.net" />
+<link rel="dns-prefetch" href="https://www.googletagmanager.com" />
+<link rel="dns-prefetch" href="https://connect.facebook.net" />
+<link rel="dns-prefetch" href="https://static.ads-twitter.com" />
 
 <!-- Font preloads -->
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link
+  rel="preload"
+  as="style"
   href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&display=swap"
-  rel="stylesheet"
+  onload="this.onload=null;this.rel='stylesheet'"
 />
+<noscript>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&display=swap"
+    rel="stylesheet"
+  />
+</noscript>
 <link
+  rel="preload"
+  as="style"
   href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap"
-  rel="stylesheet"
+  onload="this.onload=null;this.rel='stylesheet'"
 />
+<noscript>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap"
+    rel="stylesheet"
+  />
+</noscript>
 <!-- Canonical URL -->
 <link rel="canonical" href={canonicalURL} />
 
@@ -70,31 +89,71 @@ const {
 <meta property="twitter:description" content={description} />
 <meta property="twitter:image" content={new URL(image, Astro.url)} />
 
-<!-- Facebook Pixel Code -->
+<!-- Deferred tracking scripts — loaded after main thread is idle -->
 <script is:inline>
-  !(function (f, b, e, v, n, t, s) {
-    if (f.fbq) return;
-    n = f.fbq = function () {
-      n.callMethod ? n.callMethod.apply(n, arguments) : n.queue.push(arguments);
-    };
-    if (!f._fbq) f._fbq = n;
-    n.push = n;
-    n.loaded = !0;
-    n.version = "2.0";
-    n.queue = [];
-    t = b.createElement(e);
-    t.async = !0;
-    t.src = v;
-    s = b.getElementsByTagName(e)[0];
-    s.parentNode.insertBefore(t, s);
-  })(
-    window,
-    document,
-    "script",
-    "https://connect.facebook.net/en_US/fbevents.js"
-  );
-  fbq("init", "654184647412382");
-  fbq("track", "PageView");
+  (function () {
+    function loadTracking() {
+      // Facebook Pixel
+      !(function (f, b, e, v, n, t, s) {
+        if (f.fbq) return;
+        n = f.fbq = function () {
+          n.callMethod ? n.callMethod.apply(n, arguments) : n.queue.push(arguments);
+        };
+        if (!f._fbq) f._fbq = n;
+        n.push = n;
+        n.loaded = !0;
+        n.version = "2.0";
+        n.queue = [];
+        t = b.createElement(e);
+        t.async = !0;
+        t.src = v;
+        s = b.getElementsByTagName(e)[0];
+        s.parentNode.insertBefore(t, s);
+      })(window, document, "script", "https://connect.facebook.net/en_US/fbevents.js");
+      fbq("init", "654184647412382");
+      fbq("track", "PageView");
+
+      // Twitter UWT
+      !(function (e, t, n, s, u, a) {
+        e.twq ||
+          ((s = e.twq = function () {
+            s.exe ? s.exe.apply(s, arguments) : s.queue.push(arguments);
+          }),
+          (s.version = "1.1"),
+          (s.queue = []),
+          (u = t.createElement(n)),
+          (u.async = !0),
+          (u.src = "https://static.ads-twitter.com/uwt.js"),
+          (a = t.getElementsByTagName(n)[0]),
+          a.parentNode.insertBefore(u, a));
+      })(window, document, "script");
+      twq("config", "o2glx");
+
+      // GTM (WT4KSXNQ)
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != "dataLayer" ? "&l=" + l : "";
+        j.async = true;
+        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, "script", "dataLayer", "GTM-WT4KSXNQ");
+
+      // HubSpot Forms
+      var hs = document.createElement("script");
+      hs.src = "https://js.hsforms.net/forms/embed/47519938.js";
+      hs.async = true;
+      document.head.appendChild(hs);
+    }
+
+    if ("requestIdleCallback" in window) {
+      requestIdleCallback(loadTracking, { timeout: 3500 });
+    } else {
+      setTimeout(loadTracking, 2000);
+    }
+  })();
 </script>
 <noscript>
   <img
@@ -104,39 +163,3 @@ const {
     src="https://www.facebook.com/tr?id=654184647412382&ev=PageView&noscript=1"
   />
 </noscript>
-<!-- End Facebook Pixel Code -->
-
-<!-- Twitter conversion tracking base code -->
-<script is:inline>
-  !(function (e, t, n, s, u, a) {
-    e.twq ||
-      ((s = e.twq =
-        function () {
-          s.exe ? s.exe.apply(s, arguments) : s.queue.push(arguments);
-        }),
-      (s.version = "1.1"),
-      (s.queue = []),
-      (u = t.createElement(n)),
-      (u.async = !0),
-      (u.src = "https://static.ads-twitter.com/uwt.js"),
-      (a = t.getElementsByTagName(n)[0]),
-      a.parentNode.insertBefore(u, a));
-  })(window, document, "script");
-  twq("config", "o2glx");
-</script>
-<!-- End Twitter conversion tracking base code -->
-
-<!-- Google Tag Manager -->
-<script is:inline>
-  (function (w, d, s, l, i) {
-    w[l] = w[l] || [];
-    w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
-    var f = d.getElementsByTagName(s)[0],
-      j = d.createElement(s),
-      dl = l != "dataLayer" ? "&l=" + l : "";
-    j.async = true;
-    j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
-    f.parentNode.insertBefore(j, f);
-  })(window, document, "script", "dataLayer", "GTM-WT4KSXNQ");
-</script>
-<!-- End Google Tag Manager -->

--- a/src/components/footer/footer.astro
+++ b/src/components/footer/footer.astro
@@ -215,7 +215,7 @@ const shouldHide = shouldHideCta(pathname);
         {
           !hideDarkToggle && (
             <>
-              <DarkModeToggle footer client:load />
+              <DarkModeToggle footer client:idle />
               <div class="h-7 w-[1.5px] bg-gray-200 dark:bg-[#3B3B3B] " />
             </>
           )
@@ -303,7 +303,7 @@ const shouldHide = shouldHideCta(pathname);
           {
             !hideDarkToggle && (
               <>
-                <DarkModeToggle footer client:load />
+                <DarkModeToggle footer client:idle />
                 <div class="h-7 w-[1.5px] bg-gray-300 dark:bg-[#3B3B3B] " />
               </>
             )
@@ -349,7 +349,7 @@ const shouldHide = shouldHideCta(pathname);
       class="flex flex-col items-center gap-3 border-b pb-6 md:items-start md:border-b-0 md:pb-0"
     >
       <p class="text-sm text-linkText">Not sure where to start?</p>
-      <SpeakToExpert size="small" client:load />
+      <SpeakToExpert size="small" client:idle />
     </div>
     <div class="flex flex-col items-center gap-3 pt-6 md:items-end md:pt-0">
       <p class="text-sm text-linkText">Stay up to date with Akash Newsletter</p>

--- a/src/components/header/header.astro
+++ b/src/components/header/header.astro
@@ -164,7 +164,7 @@ const navContainerClass = hideContainer ? "" : "container";
 
         <TryAkashForm client:load type="headerDeploy" />
       </div>
-      {!hideDarkToggle && <DarkModeToggle client:load />}
+      {!hideDarkToggle && <DarkModeToggle client:idle />}
     </div>
   </nav>
 </header>

--- a/src/components/home/fuelNew.astro
+++ b/src/components/home/fuelNew.astro
@@ -8,7 +8,7 @@ import Dither from "@/components/backgrounds/Dither";
   >
   <div class="absolute inset-0 z-0 opacity-15">
     <Dither
-      client:load
+      client:visible
       waveColor={[0.5,0.5,0.5]}
       colorNum={3}
       disableAnimation={false}

--- a/src/components/home/hero/hero.astro
+++ b/src/components/home/hero/hero.astro
@@ -111,6 +111,8 @@ const tiles = [
                         <img
                           src={tile.image}
                           alt=""
+                          loading={i === 0 ? "eager" : "lazy"}
+                          decoding={i === 0 ? "auto" : "async"}
                           class="h-[350px] w-full block rounded-tl-2xl object-cover object-left-top"
                         />
                         <div class="hero-image-overlay opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
@@ -164,6 +166,9 @@ const tiles = [
                   <img
                     src={tile.image}
                     alt=""
+                    loading={i === 0 ? "eager" : "lazy"}
+                    decoding={i === 0 ? "auto" : "async"}
+                    fetchpriority={i === 0 ? "high" : "low"}
                     class="w-full block"
                   />
                   <div class="hero-image-overlay opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">

--- a/src/components/home/infrastructure/infrastructureNew.astro
+++ b/src/components/home/infrastructure/infrastructureNew.astro
@@ -77,6 +77,8 @@ const features: Feature[] = [
           <img
             src={feature.image}
             alt={feature.title}
+            loading="lazy"
+            decoding="async"
             class="feature-img-desktop w-full h-auto select-none pointer-events-none max-w-2xs md:max-w-full"
           />
 
@@ -84,6 +86,8 @@ const features: Feature[] = [
           <img
             src={feature.mobileImage}
             alt={feature.title}
+            loading="lazy"
+            decoding="async"
             class="feature-img-mobile w-full h-full object-cover select-none pointer-events-none"
           />
 

--- a/src/components/home/shipIt.astro
+++ b/src/components/home/shipIt.astro
@@ -5,7 +5,7 @@ import Dither from "@/components/backgrounds/Dither";
 <section class="relative w-full h-fit overflow-hidden">
   <div class="absolute inset-0 z-0 opacity-15">
     <Dither
-      client:load
+      client:visible
       waveColor={[0.5,0.5,0.5]}
       colorNum={3}
       disableAnimation={false}

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -41,10 +41,6 @@ const htmlDataTheme = onlyDark ? "dark-plus" : undefined;
   data-theme={htmlDataTheme}
 >
   <head>
-    <script
-      is:inline
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=G-LFRGN2J2RV"></script>
     <script is:inline>
       const doc = document.documentElement;
       if (doc.dataset.onlyDark === "true") {
@@ -60,32 +56,42 @@ const htmlDataTheme = onlyDark ? "dark-plus" : undefined;
       function gtag() {
         dataLayer.push(arguments);
       }
-      gtag("js", new Date());
 
-      gtag("config", "G-LFRGN2J2RV");
-    </script>
+      (function () {
+        function loadGA() {
+          var s = document.createElement("script");
+          s.async = true;
+          s.src = "https://www.googletagmanager.com/gtag/js?id=G-LFRGN2J2RV";
+          document.head.appendChild(s);
+          gtag("js", new Date());
+          gtag("config", "G-LFRGN2J2RV");
 
-    <!-- Start of HubSpot Embed Code -->
-    <script
-      is:inline
-      type="text/javascript"
-      id="hs-script-loader"
-      async
-      defer
-      src="//js.hs-scripts.com/47519938.js"
-    ></script><!-- End of HubSpot Embed Code -->
+          // GTM (573RDG5H)
+          (function (w, d, s, l, i) {
+            w[l] = w[l] || [];
+            w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+            var f = d.getElementsByTagName(s)[0],
+              j = d.createElement(s),
+              dl = l != "dataLayer" ? "&l=" + l : "";
+            j.async = true;
+            j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+            f.parentNode.insertBefore(j, f);
+          })(window, document, "script", "dataLayer", "GTM-573RDG5H");
 
-    <script is:inline>
-      (function (w, d, s, l, i) {
-        w[l] = w[l] || [];
-        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != "dataLayer" ? "&l=" + l : "";
-        j.async = true;
-        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
-        f.parentNode.insertBefore(j, f);
-      })(window, document, "script", "dataLayer", "GTM-573RDG5H");
+          // HubSpot
+          var hs = document.createElement("script");
+          hs.src = "//js.hs-scripts.com/47519938.js";
+          hs.async = true;
+          hs.defer = true;
+          document.head.appendChild(hs);
+        }
+
+        if ("requestIdleCallback" in window) {
+          requestIdleCallback(loadGA, { timeout: 3500 });
+        } else {
+          setTimeout(loadGA, 2000);
+        }
+      })();
     </script>
 
     <BaseHead
@@ -379,10 +385,20 @@ const htmlDataTheme = onlyDark ? "dark-plus" : undefined;
       observer.observe(document.documentElement, { attributes: true });
       observer.observe(document.body, { attributes: true });
     </script>
-    <script
-      is:inline
-      async
-      src="https://pxl.growth-channel.net/s/8d425860-cf3c-49cf-a459-069a7dc7b1f8"
-    ></script>
+    <script is:inline>
+      (function () {
+        function loadGrowthChannel() {
+          var s = document.createElement("script");
+          s.async = true;
+          s.src = "https://pxl.growth-channel.net/s/8d425860-cf3c-49cf-a459-069a7dc7b1f8";
+          document.body.appendChild(s);
+        }
+        if ("requestIdleCallback" in window) {
+          requestIdleCallback(loadGrowthChannel, { timeout: 5000 });
+        } else {
+          setTimeout(loadGrowthChannel, 3000);
+        }
+      })();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Defer all third-party tracking scripts (GA, GTM, Facebook Pixel, Twitter UWT, HubSpot, Growth Channel) via `requestIdleCallback` so they no longer block the main thread during initial page load
- Convert render-blocking Google Fonts to async preload with noscript fallback
- Add `dns-prefetch` hints for third-party domains to speed up DNS resolution
- Change below-fold WebGL Dither backgrounds from `client:load` to `client:visible` (fuelNew, shipIt)
- Change footer DarkModeToggle + SpeakToExpert and header DarkModeToggle from `client:load` to `client:idle`
- Add `loading="lazy"` and `decoding="async"` to below-fold infrastructure images
- Add `fetchpriority="high"` to the first hero image, lazy load the rest

## Test plan
- [ ] Run Lighthouse/PageSpeed Insights on homepage — confirm improved Performance score
- [ ] Verify Google Analytics and GTM still fire correctly (check network tab after idle)
- [ ] Verify Facebook Pixel and Twitter UWT tracking events still fire
- [ ] Verify HubSpot forms still load and work
- [ ] Check fonts render correctly (no FOUT regressions)
- [ ] Verify Dither backgrounds appear when scrolled into view
- [ ] Verify dark mode toggle works in header and footer
- [ ] Test on mobile devices for consistent behavior