### PR TITLE
fix: remove duplicate GA4 and migrate to new GTM container

### DIFF
--- a/src/components/base-head.astro
+++ b/src/components/base-head.astro
@@ -156,7 +156,7 @@ const {
     })(window, document, "script");
     twq("config", "o2glx");
 
-    // Google Tag Manager (GTM-WT4KSXNQ)
+    // Google Tag Manager (GTM-MSF384N3) — single source of truth for GA4
     (function (w, d, s, l, i) {
       w[l] = w[l] || [];
       w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
@@ -166,7 +166,7 @@ const {
       j.async = true;
       j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
       f.parentNode.insertBefore(j, f);
-    })(window, document, "script", "dataLayer", "GTM-WT4KSXNQ");
+    })(window, document, "script", "dataLayer", "GTM-MSF384N3");
   }
 
   if (document.readyState === 'complete') {

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -51,36 +51,13 @@ const htmlDataTheme = onlyDark ? "dark-plus" : undefined;
     </script>
     <script is:inline>
       window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
-      gtag("config", "G-LFRGN2J2RV");
     </script>
 
-    <!-- GA & GTM & HubSpot - deferred until after page load -->
+    <!-- HubSpot - deferred until after page load -->
     <script is:inline>
       function _loadAnalytics() {
         if (window._analyticsLoaded) return;
         window._analyticsLoaded = true;
-
-        // Google Analytics
-        var ga = document.createElement('script');
-        ga.async = true;
-        ga.src = 'https://www.googletagmanager.com/gtag/js?id=G-LFRGN2J2RV';
-        document.head.appendChild(ga);
-
-        // GTM (GTM-573RDG5H)
-        (function (w, d, s, l, i) {
-          w[l] = w[l] || [];
-          w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
-          var f = d.getElementsByTagName(s)[0],
-            j = d.createElement(s),
-            dl = l != "dataLayer" ? "&l=" + l : "";
-          j.async = true;
-          j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
-          f.parentNode.insertBefore(j, f);
-        })(window, document, "script", "dataLayer", "GTM-573RDG5H");
 
         // HubSpot
         var hs = document.createElement('script');
@@ -207,7 +184,7 @@ const htmlDataTheme = onlyDark ? "dark-plus" : undefined;
     <!-- Google Tag Manager (noscript) -->
     <noscript
       ><iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WT4KSXNQ"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MSF384N3"
         height="0"
         width="0"
         style="display:none;visibility:hidden"></iframe></noscript


### PR DESCRIPTION
## Summary
- **Removed inline GA4 (gtag.js)** — `gtag('config', 'G-LFRGN2J2RV')` and the gtag.js script loader were firing a `page_view` independently of GTM, causing duplicate pageviews
- **Removed old GTM-573RDG5H** container that was bundled with the direct GA4 load
- **Replaced GTM-WT4KSXNQ → GTM-MSF384N3** — new container has GA4 fully configured inside it, making GTM the single source of truth
- **Kept** `window.dataLayer` init (required for GTM) and all other trackers (Facebook Pixel, Twitter, HubSpot) untouched

## Why
GA4 was double-counting every pageview: once from the inline gtag.js call and once from the GTM container's own GA4 tag. The old GTM container (GTM-WT4KSXNQ) was not under GA4 ownership. The new container (GTM-MSF384N3) is fully configured with GA4, so direct gtag.js loading is no longer needed.

## Expected behavior after merge
Page loads → GTM-MSF384N3 loads → GA4 tag inside GTM fires → **one** `page_view` sent to G-LFRGN2J2RV. No direct GA4 calls anywhere.

## Test plan
- [ ] Verify in GA4 Realtime that only one `page_view` fires per navigation
- [ ] Confirm GTM-MSF384N3 loads via browser DevTools (Network tab → `gtm.js`)
- [ ] Confirm no `gtag.js` requests in Network tab
- [ ] Verify Facebook Pixel, Twitter, and HubSpot still fire correctly
- [ ] Check GTM preview mode to confirm GA4 tag fires inside the container