### PR TITLE
revert: remove analytics config commit (141ed1aa)

### DIFF
--- a/src/components/base-head.astro
+++ b/src/components/base-head.astro
@@ -108,66 +108,74 @@ const {
 <meta property="twitter:description" content={description} />
 <meta property="twitter:image" content={new URL(image, Astro.url)} />
 
-<!-- Facebook Pixel Code -->
+<!-- Third-party tracking scripts - deferred until after page load -->
 <script is:inline>
-  !(function (f, b, e, v, n, t, s) {
-    if (f.fbq) return;
-    n = f.fbq = function () {
-      n.callMethod ? n.callMethod.apply(n, arguments) : n.queue.push(arguments);
-    };
-    if (!f._fbq) f._fbq = n;
-    n.push = n;
-    n.loaded = !0;
-    n.version = "2.0";
-    n.queue = [];
-    t = b.createElement(e);
-    t.async = !0;
-    t.src = v;
-    s = b.getElementsByTagName(e)[0];
-    s.parentNode.insertBefore(t, s);
-  })(
-    window,
-    document,
-    "script",
-    "https://connect.facebook.net/en_US/fbevents.js"
-  );
-  fbq("init", "654184647412382");
-  fbq("track", "PageView");
-</script>
-<!-- End Facebook Pixel Code -->
+  function _loadThirdPartyTrackers() {
+    if (window._thirdPartyTrackersLoaded) return;
+    window._thirdPartyTrackersLoaded = true;
 
-<!-- Twitter conversion tracking base code -->
-<script is:inline>
-  !(function (e, t, n, s, u, a) {
-    e.twq ||
-      ((s = e.twq =
-        function () {
-          s.exe ? s.exe.apply(s, arguments) : s.queue.push(arguments);
-        }),
-      (s.version = "1.1"),
-      (s.queue = []),
-      (u = t.createElement(n)),
-      (u.async = !0),
-      (u.src = "https://static.ads-twitter.com/uwt.js"),
-      (a = t.getElementsByTagName(n)[0]),
-      a.parentNode.insertBefore(u, a));
-  })(window, document, "script");
-  twq("config", "o2glx");
-</script>
-<!-- End Twitter conversion tracking base code -->
+    // Facebook Pixel
+    !(function (f, b, e, v, n, t, s) {
+      if (f.fbq) return;
+      n = f.fbq = function () {
+        n.callMethod ? n.callMethod.apply(n, arguments) : n.queue.push(arguments);
+      };
+      if (!f._fbq) f._fbq = n;
+      n.push = n;
+      n.loaded = !0;
+      n.version = "2.0";
+      n.queue = [];
+      t = b.createElement(e);
+      t.async = !0;
+      t.src = v;
+      s = b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t, s);
+    })(
+      window,
+      document,
+      "script",
+      "https://connect.facebook.net/en_US/fbevents.js"
+    );
+    fbq("init", "654184647412382");
+    fbq("track", "PageView");
 
-<!-- Google Tag Manager -->
-<script is:inline>
-  (function (w, d, s, l, i) {
-    w[l] = w[l] || [];
-    w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
-    var f = d.getElementsByTagName(s)[0],
-      j = d.createElement(s),
-      dl = l != "dataLayer" ? "&l=" + l : "";
-    j.async = true;
-    j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
-    f.parentNode.insertBefore(j, f);
-  })(window, document, "script", "dataLayer", "GTM-WT4KSXNQ");
+    // Twitter conversion tracking
+    !(function (e, t, n, s, u, a) {
+      e.twq ||
+        ((s = e.twq =
+          function () {
+            s.exe ? s.exe.apply(s, arguments) : s.queue.push(arguments);
+          }),
+        (s.version = "1.1"),
+        (s.queue = []),
+        (u = t.createElement(n)),
+        (u.async = !0),
+        (u.src = "https://static.ads-twitter.com/uwt.js"),
+        (a = t.getElementsByTagName(n)[0]),
+        a.parentNode.insertBefore(u, a));
+    })(window, document, "script");
+    twq("config", "o2glx");
+
+    // Google Tag Manager (GTM-WT4KSXNQ)
+    (function (w, d, s, l, i) {
+      w[l] = w[l] || [];
+      w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+      var f = d.getElementsByTagName(s)[0],
+        j = d.createElement(s),
+        dl = l != "dataLayer" ? "&l=" + l : "";
+      j.async = true;
+      j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+      f.parentNode.insertBefore(j, f);
+    })(window, document, "script", "dataLayer", "GTM-WT4KSXNQ");
+  }
+
+  if (document.readyState === 'complete') {
+    setTimeout(_loadThirdPartyTrackers, 0);
+  } else {
+    window.addEventListener('load', function() {
+      setTimeout(_loadThirdPartyTrackers, 100);
+    });
+  }
 </script>
 <noscript>
   <img

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -39,10 +39,6 @@ const htmlDataTheme = onlyDark ? "dark-plus" : undefined;
   data-theme={htmlDataTheme}
 >
   <head>
-    <script
-      is:inline
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=G-LFRGN2J2RV"></script>
     <script is:inline>
       const doc = document.documentElement;
       if (doc.dataset.onlyDark === "true") {
@@ -59,31 +55,48 @@ const htmlDataTheme = onlyDark ? "dark-plus" : undefined;
         dataLayer.push(arguments);
       }
       gtag("js", new Date());
-
       gtag("config", "G-LFRGN2J2RV");
     </script>
 
-    <!-- Start of HubSpot Embed Code -->
-    <script
-      is:inline
-      type="text/javascript"
-      id="hs-script-loader"
-      async
-      defer
-      src="//js.hs-scripts.com/47519938.js"
-    ></script><!-- End of HubSpot Embed Code -->
-
+    <!-- GA & GTM & HubSpot - deferred until after page load -->
     <script is:inline>
-      (function (w, d, s, l, i) {
-        w[l] = w[l] || [];
-        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != "dataLayer" ? "&l=" + l : "";
-        j.async = true;
-        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
-        f.parentNode.insertBefore(j, f);
-      })(window, document, "script", "dataLayer", "GTM-573RDG5H");
+      function _loadAnalytics() {
+        if (window._analyticsLoaded) return;
+        window._analyticsLoaded = true;
+
+        // Google Analytics
+        var ga = document.createElement('script');
+        ga.async = true;
+        ga.src = 'https://www.googletagmanager.com/gtag/js?id=G-LFRGN2J2RV';
+        document.head.appendChild(ga);
+
+        // GTM (GTM-573RDG5H)
+        (function (w, d, s, l, i) {
+          w[l] = w[l] || [];
+          w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+          var f = d.getElementsByTagName(s)[0],
+            j = d.createElement(s),
+            dl = l != "dataLayer" ? "&l=" + l : "";
+          j.async = true;
+          j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+          f.parentNode.insertBefore(j, f);
+        })(window, document, "script", "dataLayer", "GTM-573RDG5H");
+
+        // HubSpot
+        var hs = document.createElement('script');
+        hs.async = true;
+        hs.id = 'hs-script-loader';
+        hs.src = '//js.hs-scripts.com/47519938.js';
+        document.head.appendChild(hs);
+      }
+
+      if (document.readyState === 'complete') {
+        setTimeout(_loadAnalytics, 0);
+      } else {
+        window.addEventListener('load', function() {
+          setTimeout(_loadAnalytics, 100);
+        });
+      }
     </script>
 
     <BaseHead


### PR DESCRIPTION
## Summary
- Reverts commit 141ed1aa (`Fix: update analytics cofig`) which should not have been on main

## Why
This commit needs to be removed before the proper GTM migration PR (#387) can be cleanly applied.