### PR TITLE
fix: remove duplicate GA4 tracking and migrate to new GTM container

### DIFF
--- a/src/components/base-head.astro
+++ b/src/components/base-head.astro
@@ -156,7 +156,7 @@ const {
     })(window, document, "script");
     twq("config", "o2glx");
 
-    // Google Tag Manager (GTM-WT4KSXNQ)
+    // Google Tag Manager (GTM-MSF384N3)
     (function (w, d, s, l, i) {
       w[l] = w[l] || [];
       w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
@@ -166,7 +166,7 @@ const {
       j.async = true;
       j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
       f.parentNode.insertBefore(j, f);
-    })(window, document, "script", "dataLayer", "GTM-WT4KSXNQ");
+    })(window, document, "script", "dataLayer", "GTM-MSF384N3");
   }
 
   if (document.readyState === 'complete') {

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -54,33 +54,13 @@ const htmlDataTheme = onlyDark ? "dark-plus" : undefined;
       function gtag() {
         dataLayer.push(arguments);
       }
-      gtag("js", new Date());
-      gtag("config", "G-LFRGN2J2RV");
     </script>
 
-    <!-- GA & GTM & HubSpot - deferred until after page load -->
+    <!-- HubSpot - deferred until after page load -->
     <script is:inline>
       function _loadAnalytics() {
         if (window._analyticsLoaded) return;
         window._analyticsLoaded = true;
-
-        // Google Analytics
-        var ga = document.createElement('script');
-        ga.async = true;
-        ga.src = 'https://www.googletagmanager.com/gtag/js?id=G-LFRGN2J2RV';
-        document.head.appendChild(ga);
-
-        // GTM (GTM-573RDG5H)
-        (function (w, d, s, l, i) {
-          w[l] = w[l] || [];
-          w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
-          var f = d.getElementsByTagName(s)[0],
-            j = d.createElement(s),
-            dl = l != "dataLayer" ? "&l=" + l : "";
-          j.async = true;
-          j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
-          f.parentNode.insertBefore(j, f);
-        })(window, document, "script", "dataLayer", "GTM-573RDG5H");
 
         // HubSpot
         var hs = document.createElement('script');
@@ -207,7 +187,7 @@ const htmlDataTheme = onlyDark ? "dark-plus" : undefined;
     <!-- Google Tag Manager (noscript) -->
     <noscript
       ><iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WT4KSXNQ"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MSF384N3"
         height="0"
         width="0"
         style="display:none;visibility:hidden"></iframe></noscript


### PR DESCRIPTION
## Summary

- **Remove direct GA4 (gtag.js)** — eliminates duplicate `page_view` events caused by GA4 firing both inline and via GTM
- **Migrate GTM container** — replace old `GTM-WT4KSXNQ` and `GTM-573RDG5H` with new GA4-integrated `GTM-MSF384N3`
- **Preserve `window.dataLayer` and `gtag()` function** — required for GTM and custom event tracking in form components

## What changed

| File | Change |
|---|---|
| `src/layouts/base-layout.astro` | Removed `gtag('config', 'G-LFRGN2J2RV')`, removed gtag.js script loading, removed `GTM-573RDG5H`, updated noscript iframe to `GTM-MSF384N3` |
| `src/components/base-head.astro` | Replaced `GTM-WT4KSXNQ` with `GTM-MSF384N3` in `_loadThirdPartyTrackers()` |

## Expected behavior after merge

1. Page loads → GTM-MSF384N3 loads → GA4 tag inside GTM fires → **one** `page_view` sent to `G-LFRGN2J2RV`
2. No direct gtag.js loaded anywhere
3. Form event tracking (`form_submission_success`, `form_submission_error`, `continue_to_console_click`) continues to work via `dataLayer`
4. Facebook Pixel, Twitter tracking, HubSpot — all untouched

## Test plan

- [ ] Verify only one `page_view` fires per page load (GA4 DebugView or Tag Assistant)
- [ ] Verify GTM-MSF384N3 loads correctly (GTM Preview mode)
- [ ] Verify form submission events reach GA4
- [ ] Verify Facebook Pixel and Twitter tracking still fire
- [ ] Verify HubSpot script still loads