### PR TITLE
fix: migrate GTM to GTM-MSF384N3

### DIFF
--- a/src/components/base-head.astro
+++ b/src/components/base-head.astro
@@ -167,7 +167,7 @@ const {
     j.async = true;
     j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
     f.parentNode.insertBefore(j, f);
-  })(window, document, "script", "dataLayer", "GTM-WT4KSXNQ");
+  })(window, document, "script", "dataLayer", "GTM-MSF384N3");
 </script>
 <noscript>
   <img

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -49,6 +49,12 @@ const htmlDataTheme = onlyDark ? "dark-plus" : undefined;
         } catch {}
       }
     </script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+    </script>
 
     <!-- Start of HubSpot Embed Code -->
     <script

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -39,10 +39,6 @@ const htmlDataTheme = onlyDark ? "dark-plus" : undefined;
   data-theme={htmlDataTheme}
 >
   <head>
-    <script
-      is:inline
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=G-LFRGN2J2RV"></script>
     <script is:inline>
       const doc = document.documentElement;
       if (doc.dataset.onlyDark === "true") {
@@ -52,15 +48,6 @@ const htmlDataTheme = onlyDark ? "dark-plus" : undefined;
           localStorage.setItem("theme", "dark");
         } catch {}
       }
-    </script>
-    <script is:inline>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
-
-      gtag("config", "G-LFRGN2J2RV");
     </script>
 
     <!-- Start of HubSpot Embed Code -->
@@ -194,7 +181,7 @@ const htmlDataTheme = onlyDark ? "dark-plus" : undefined;
     <!-- Google Tag Manager (noscript) -->
     <noscript
       ><iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WT4KSXNQ"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MSF384N3"
         height="0"
         width="0"
         style="display:none;visibility:hidden"></iframe></noscript


### PR DESCRIPTION
## Summary
- Removed inline GA4 script loader (`gtag/js?id=G-LFRGN2J2RV`) and config block from `base-layout.astro` — GA4 now fires only via GTM (no duplicate loads)
- Migrated GTM container ID from `GTM-WT4KSXNQ` to `GTM-MSF384N3` in both `base-head.astro` (head script) and `base-layout.astro` (noscript iframe)
- `GTM-573RDG5H`, Facebook Pixel, Twitter, HubSpot, and Contentsquare are unchanged

## Verification
- All 124 real content pages (including docs, community, about) confirmed to have `GTM-MSF384N3` (2x: head + noscript) and `GTM-573RDG5H` (1x)
- Zero pages contain `G-LFRGN2J2RV` or `GTM-WT4KSXNQ`
- Zero pages have `gtag("config", ...)` calls — GA4 fires only through GTM
- 11 redirect-only pages (Astro `meta refresh`) have no analytics as expected — users bounce instantly to destination pages with full tracking
- Full build passes (568 pages)

## Test plan
- [ ] Verify GTM-MSF384N3 loads in browser network tab on homepage, docs, community, and about pages
- [ ] Confirm GA4 fires exactly once per page in GA4 DebugView
- [ ] Confirm no `gtag/js?id=G-LFRGN2J2RV` requests in network tab
- [ ] Verify Facebook Pixel, Twitter, HubSpot, Contentsquare still fire normally