### PR TITLE
fix: remove GTM-573RDG5H 

### DIFF
--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -66,19 +66,6 @@ const htmlDataTheme = onlyDark ? "dark-plus" : undefined;
       src="//js.hs-scripts.com/47519938.js"
     ></script><!-- End of HubSpot Embed Code -->
 
-    <script is:inline>
-      (function (w, d, s, l, i) {
-        w[l] = w[l] || [];
-        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != "dataLayer" ? "&l=" + l : "";
-        j.async = true;
-        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
-        f.parentNode.insertBefore(j, f);
-      })(window, document, "script", "dataLayer", "GTM-573RDG5H");
-    </script>
-
     <BaseHead
       title={title}
       description={description}


### PR DESCRIPTION
## Summary
- Removed the duplicate GTM container `GTM-573RDG5H` from `base-layout.astro` that was loading alongside `GTM-MSF384N3`, causing double-counted analytics events
- `GTM-MSF384N3` (in `base-head.astro` + noscript iframe) remains as the single GTM source of truth
- All other tracking unchanged: Facebook Pixel, Twitter, HubSpot, Growth Channel, dataLayer/gtag bridge

## Test plan
- [ ] Verify GA4 real-time report shows normal traffic (no duplicate events)
- [ ] Confirm GTM-MSF384N3 container loads correctly via browser Network tab
- [ ] Check that `dataLayer` and `gtag()` calls still fire (e.g. form submissions on GPU contact form)
- [ ] Verify Facebook Pixel, Twitter, HubSpot tracking still operational