### PR TITLE
Add:  SPA page tracking for GA

### DIFF
--- a/src/components/base-head.astro
+++ b/src/components/base-head.astro
@@ -18,7 +18,6 @@ const {
 
 <!-- Global Metadata -->
 <meta charset="utf-8" />
-<meta
   name="viewport"
   content="width=device-width,initial-scale=1"
 />
@@ -177,3 +176,37 @@ const {
     src="https://www.facebook.com/tr?id=654184647412382&ev=PageView&noscript=1"
   />
 </noscript>
+
+<script is:inline>
+  let isFirstLoad = true;
+
+  document.addEventListener("astro:page-load", () => {
+    if (isFirstLoad) {
+      isFirstLoad = false;
+      return; // dont touch the initial page load since gtm script will handle it
+    }
+
+    // ga4 via gtm
+    if (typeof window.dataLayer !== "undefined") {
+      window.dataLayer.push({
+        event: "page_view",
+        page_path: window.location.pathname + window.location.search,
+        page_title: document.title,
+        page_location: window.location.href,
+      });
+    }
+
+    // facebook pixel
+    if (typeof fbq !== "undefined") {
+      fbq("track", "PageView");
+    }
+
+    // twitter conversion tracking
+    if (typeof twq !== "undefined") {
+      twq("event", "page_view", {
+        page_path: window.location.pathname + window.location.search,
+        page_title: document.title,
+      });
+    }
+  });
+</script>

--- a/src/components/base-head.astro
+++ b/src/components/base-head.astro
@@ -18,9 +18,7 @@ const {
 
 <!-- Global Metadata -->
 <meta charset="utf-8" />
-  name="viewport"
-  content="width=device-width,initial-scale=1"
-/>
+<meta name="viewport" content="width=device-width,initial-scale=1" />
 <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
 <meta name="generator" content={Astro.generator} />
 
@@ -47,11 +45,11 @@ const {
   function _loadHubSpotForms() {
     if (window._hubSpotFormsLoaded) return;
     window._hubSpotFormsLoaded = true;
-    var s = document.createElement('script');
-    s.src = 'https://js.hsforms.net/forms/embed/47519938.js';
+    var s = document.createElement("script");
+    s.src = "https://js.hsforms.net/forms/embed/47519938.js";
     document.head.appendChild(s);
   }
-  if ('requestIdleCallback' in window) {
+  if ("requestIdleCallback" in window) {
     requestIdleCallback(_loadHubSpotForms);
   } else {
     setTimeout(_loadHubSpotForms, 2000);
@@ -67,14 +65,24 @@ const {
   href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&display=swap"
   onload="this.rel='stylesheet'"
 />
-<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&display=swap" /></noscript>
+<noscript
+  ><link
+    rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&display=swap"
+  /></noscript
+>
 <link
   rel="preload"
   as="style"
   href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap"
   onload="this.rel='stylesheet'"
 />
-<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap" /></noscript>
+<noscript
+  ><link
+    rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap"
+  /></noscript
+>
 
 <!-- Canonical URL -->
 <link rel="canonical" href={canonicalURL} />
@@ -128,7 +136,7 @@ const {
     window,
     document,
     "script",
-    "https://connect.facebook.net/en_US/fbevents.js"
+    "https://connect.facebook.net/en_US/fbevents.js",
   );
   fbq("init", "654184647412382");
   fbq("track", "PageView");
@@ -168,6 +176,7 @@ const {
     f.parentNode.insertBefore(j, f);
   })(window, document, "script", "dataLayer", "GTM-MSF384N3");
 </script>
+
 <noscript>
   <img
     height="1"


### PR DESCRIPTION
This pull request makes several improvements to the `src/components/base-head.astro` file, focusing on code consistency, formatting, and enhanced analytics tracking for client-side navigation. The most significant change is the addition of a script that ensures analytics events (GA4 via GTM, Facebook Pixel, Twitter conversion tracking) are triggered correctly on client-side page transitions, not just on initial page load. Other changes include code style adjustments for consistency and better readability.

Added an inline `<script>` to listen for `astro:page-load` events and trigger GA4 (via GTM), Facebook Pixel, and Twitter conversion tracking on client-side navigations, ensuring analytics are accurate for single-page app transitions.