### PR TITLE
fix(gpu-pricing): display name for RTX Pro 6000 Blackwell Max-Q

### DIFF
--- a/src/components/pricing-page/gpus/gpu-table.tsx
+++ b/src/components/pricing-page/gpus/gpu-table.tsx
@@ -130,6 +130,8 @@ export const modifyModel = (model: string) => {
   if (model === "rtxa6000") return "A6000";
   if (model === "pro6000se") return "Pro 6000 SE";
   if (model === "pro6000we") return "Pro 6000 WE";
+  if (model === "rtxpro6000blackwellmaxqworkstationedition")
+    return "RTX Pro 6000 Blackwell Max-Q";
   return formatText(model);
 };
 


### PR DESCRIPTION
## Summary
- The GPU pricing page was rendering one model as **RTX Pro6000blackwellmaxqworksta Tionedi Tion** instead of the intended name.
- Root cause: `formatText()` in `src/components/pricing-page/gpus/gpu-table.tsx` applies a case-insensitive `/ti/gi` replacement without word boundaries, so the API string `rtxpro6000blackwellmaxqworkstationedition` gets mangled — the `ti` inside `worksta[ti]on` and `edi[ti]on` is replaced with ` Ti`, fragmenting the name.
- Fix: add an explicit mapping in `modifyModel()` for `rtxpro6000blackwellmaxqworkstationedition → "RTX Pro 6000 Blackwell Max-Q"`, matching the existing pattern already used for `pro6000se`, `pro6000we`, and `rtxa6000`. Minimal, surgical, no risk of regressing other models.

## Before / After
- Before: `RTX Pro6000blackwellmaxqworksta Tionedi Tion`
- After: `RTX Pro 6000 Blackwell Max-Q`

## Test plan
- [ ] Visit `/pricing/gpus` on a CORS-approved origin (akash.network) and confirm the 95GB VRAM row renders as **RTX Pro 6000 Blackwell Max-Q**
- [ ] Confirm the model name also renders correctly in the filter dropdown and in the active-filters chip when selected
- [ ] Verify the row layout on mobile, tablet, and desktop — name wraps naturally on spaces and does not overflow
- [ ] Sanity-check other GPU rows (A100, H100, H200, RTX 4090, RTX 5090, Pro 6000 SE / WE, RTX 3090 Ti, RTX 4000 Ada) still render correctly
